### PR TITLE
feat: EqMonitorEewReplayData + ReplayGenerator Worker Service

### DIFF
--- a/src/KyoshinEewViewer.Core/Models/EarthquakeReplay/KyoshinReplayFileReader.cs
+++ b/src/KyoshinEewViewer.Core/Models/EarthquakeReplay/KyoshinReplayFileReader.cs
@@ -113,6 +113,7 @@ public enum ReplayFileCompressionMode
 [Union(1000, typeof(KEViJsonReplayData))]
 [Union(1001, typeof(SNPLogEntryReplayData))]
 [Union(1002, typeof(AxisJsonReplayData))]
+[Union(1003, typeof(EqMonitorEewReplayData))]
 public abstract class ReplayData
 {
 	[Key(0)]
@@ -190,6 +191,17 @@ public class SNPLogEntryReplayData : ReplayData
 
 [MessagePackObject]
 public class AxisJsonReplayData : ReplayData
+{
+	[Key(1)]
+	public string Json { get; set; }
+}
+
+/// <summary>
+/// EQMonitor の EventMessage 型 JSON を保持するリプレイデータ。
+/// 旧クライアントは Union Key 1003 を未知としてスキップするため後方互換。
+/// </summary>
+[MessagePackObject]
+public class EqMonitorEewReplayData : ReplayData
 {
 	[Key(1)]
 	public string Json { get; set; }

--- a/src/KyoshinEewViewer/Series/KyoshinMonitor/Models/EqMonitorEventMessage.cs
+++ b/src/KyoshinEewViewer/Series/KyoshinMonitor/Models/EqMonitorEventMessage.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace KyoshinEewViewer.Series.KyoshinMonitor.Models;
+
+/// <summary>
+/// EQMonitor Backend の EventMessage JSON をデシリアライズするモデル。
+/// リプレイファイル内の EqMonitorEewReplayData.Json を変換する際に使用。
+/// </summary>
+public class EqMonitorEventMessage
+{
+	[JsonPropertyName("eventId")]
+	public string EventId { get; set; } = "";
+
+	[JsonPropertyName("type")]
+	public string Type { get; set; } = "";
+
+	[JsonPropertyName("serialNo")]
+	public int SerialNo { get; set; }
+
+	[JsonPropertyName("reportTime")]
+	public string ReportTime { get; set; } = "";
+
+	[JsonPropertyName("originTime")]
+	public string? OriginTime { get; set; }
+
+	[JsonPropertyName("arrivalTime")]
+	public string? ArrivalTime { get; set; }
+
+	[JsonPropertyName("maxIntensity")]
+	public string? MaxIntensity { get; set; }
+
+	[JsonPropertyName("magnitude")]
+	public double? Magnitude { get; set; }
+
+	[JsonPropertyName("isWarning")]
+	public bool? IsWarning { get; set; }
+
+	[JsonPropertyName("isLastInfo")]
+	public bool? IsLastInfo { get; set; }
+
+	[JsonPropertyName("isCancel")]
+	public bool? IsCancel { get; set; }
+
+	[JsonPropertyName("hypocenter")]
+	public EqMonitorHypocenter? Hypocenter { get; set; }
+
+	[JsonPropertyName("regions")]
+	public List<EqMonitorRegion> Regions { get; set; } = [];
+}
+
+public class EqMonitorHypocenter
+{
+	[JsonPropertyName("latitude")]
+	public double Latitude { get; set; }
+
+	[JsonPropertyName("longitude")]
+	public double Longitude { get; set; }
+
+	[JsonPropertyName("depth")]
+	public int Depth { get; set; }
+
+	[JsonPropertyName("name")]
+	public string? Name { get; set; }
+}
+
+public class EqMonitorRegion
+{
+	[JsonPropertyName("code")]
+	public string Code { get; set; } = "";
+
+	[JsonPropertyName("name")]
+	public string Name { get; set; } = "";
+
+	[JsonPropertyName("intensity")]
+	public string Intensity { get; set; } = "";
+}

--- a/src/KyoshinEewViewer/Series/KyoshinMonitor/Models/EqMonitorEventMessageConverter.cs
+++ b/src/KyoshinEewViewer/Series/KyoshinMonitor/Models/EqMonitorEventMessageConverter.cs
@@ -1,0 +1,90 @@
+using KyoshinMonitorLib;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+namespace KyoshinEewViewer.Series.KyoshinMonitor.Models;
+
+/// <summary>
+/// EQMonitor Backend の EventMessage JSON → C# の Eew レコードへの変換
+/// </summary>
+public static class EqMonitorEventMessageConverter
+{
+	public static Eew? ToEew(EqMonitorEventMessage msg, DateTime replayTime)
+	{
+		if (msg.IsCancel == true)
+			return new Eew
+			{
+				Id = msg.EventId,
+				Source = EewSource.Dmdata,
+				DisplaySource = "EQMonitor リプレイ",
+				ReceiveTime = replayTime,
+				SerialNo = msg.SerialNo,
+				IsFinal = false,
+				IsCancelled = true,
+				IsTrueCancelled = true,
+				Hypocenter = null,
+				IsWarning = msg.IsWarning ?? false,
+			};
+
+		DateTime occurrenceTime;
+		if (!string.IsNullOrEmpty(msg.OriginTime) && DateTime.TryParse(msg.OriginTime, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var ot))
+			occurrenceTime = ot;
+		else if (!string.IsNullOrEmpty(msg.ArrivalTime) && DateTime.TryParse(msg.ArrivalTime, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var at))
+			occurrenceTime = at;
+		else
+			occurrenceTime = replayTime;
+
+		var intensityMap = msg.Regions
+			.Select(r => (Code: int.TryParse(r.Code, out var c) ? c : -1, Intensity: ParseJmaIntensity(r.Intensity)))
+			.Where(r => r.Code >= 0 && r.Intensity != JmaIntensity.Unknown)
+			.GroupBy(r => r.Code)
+			.ToDictionary(g => g.Key, g => g.Max(r => r.Intensity));
+
+		return new Eew
+		{
+			Id = msg.EventId,
+			Source = EewSource.Dmdata,
+			DisplaySource = "EQMonitor リプレイ",
+			ReceiveTime = replayTime,
+			SerialNo = msg.SerialNo,
+			IsFinal = msg.IsLastInfo ?? false,
+			MaxIntensity = ParseJmaIntensity(msg.MaxIntensity),
+			Hypocenter = msg.Hypocenter != null
+				? new EewHypocenter
+				{
+					OccurrenceTime = occurrenceTime,
+					Place = msg.Hypocenter.Name,
+					Location = new Location((float)msg.Hypocenter.Latitude, (float)msg.Hypocenter.Longitude),
+					Magnitude = msg.Magnitude.HasValue ? (float)msg.Magnitude.Value : null,
+					Depth = msg.Hypocenter.Depth,
+					IsTemporary = false,
+				}
+				: null,
+			IntensityForecastMap = intensityMap.Count > 0 ? intensityMap : null,
+			IsWarning = msg.IsWarning ?? false,
+		};
+	}
+
+	private static JmaIntensity ParseJmaIntensity(string? value)
+	{
+		if (string.IsNullOrEmpty(value))
+			return JmaIntensity.Unknown;
+
+		return value switch
+		{
+			"0" or "!0" => JmaIntensity.Int0,
+			"1" or "!1" => JmaIntensity.Int1,
+			"2" or "!2" => JmaIntensity.Int2,
+			"3" or "!3" => JmaIntensity.Int3,
+			"4" or "!4" => JmaIntensity.Int4,
+			"5-" or "!5-" => JmaIntensity.Int5Lower,
+			"5+" or "!5+" => JmaIntensity.Int5Upper,
+			"6-" or "!6-" => JmaIntensity.Int6Lower,
+			"6+" or "!6+" => JmaIntensity.Int6Upper,
+			"7" or "!7" => JmaIntensity.Int7,
+			_ => JmaIntensity.Unknown,
+		};
+	}
+}

--- a/src/KyoshinEewViewer/Series/KyoshinMonitor/ReplayFileEarthquakeInformationHost.cs
+++ b/src/KyoshinEewViewer/Series/KyoshinMonitor/ReplayFileEarthquakeInformationHost.cs
@@ -231,21 +231,24 @@ public class ReplayFileEarthquakeInformationHost : EarthquakeInformationHost
 					case JmaXmlTelegramReplayData jma:
 						ProcessJmaXmlEew(jma.Telegram, time);
 						break;
-					case KEViJsonReplayData kevi:
-						switch (kevi.Type)
-						{
-							case KEViJsonReplayData.JsonType.Eew:
-								var eew = JsonSerializer.Deserialize<Eew>(kevi.Json);
-								if (eew != null)
-									EewController.Update(eew, time);
-								break;
-							case KEViJsonReplayData.JsonType.EewWarning:
-								var eewWarning = JsonSerializer.Deserialize<Eew>(kevi.Json);
-								if (eewWarning != null)
-									EewController.UpdateWarning(eewWarning, time);
-								break;
-						}
-						break;
+				case KEViJsonReplayData kevi:
+					switch (kevi.Type)
+					{
+						case KEViJsonReplayData.JsonType.Eew:
+							var eew = JsonSerializer.Deserialize<Eew>(kevi.Json);
+							if (eew != null)
+								EewController.Update(eew, time);
+							break;
+						case KEViJsonReplayData.JsonType.EewWarning:
+							var eewWarning = JsonSerializer.Deserialize<Eew>(kevi.Json);
+							if (eewWarning != null)
+								EewController.UpdateWarning(eewWarning, time);
+							break;
+					}
+					break;
+				case EqMonitorEewReplayData eqMonitorEew:
+					ProcessEqMonitorEew(eqMonitorEew.Json, time);
+					break;
 				}
 			}
 
@@ -418,6 +421,28 @@ public class ReplayFileEarthquakeInformationHost : EarthquakeInformationHost
 			} : null,
 			IsWarning = report.EarthquakeBody.Comments?.WarningCommentCode?.Contains("0201") ?? false,
 		};
+
+		EewController.Update(eew, time);
+	}
+
+	private void ProcessEqMonitorEew(string json, DateTime time)
+	{
+		var msg = JsonSerializer.Deserialize<EqMonitorEventMessage>(json);
+		if (msg == null)
+			return;
+
+		if (msg.IsCancel == true)
+		{
+			EewController.Cancelled(msg.EventId, time);
+			return;
+		}
+
+		var eew = EqMonitorEventMessageConverter.ToEew(msg, time);
+		if (eew == null)
+			return;
+
+		if (eew.IsWarning)
+			EewController.UpdateWarning(eew, time);
 
 		EewController.Update(eew, time);
 	}

--- a/src/Services/ReplayGenerator/Domain/ReplayFileBuilder.cs
+++ b/src/Services/ReplayGenerator/Domain/ReplayFileBuilder.cs
@@ -1,0 +1,155 @@
+using KyoshinEewViewer.Core.Models.EarthquakeReplay;
+using KyoshinMonitorLib;
+using KyoshinMonitorLib.UrlGenerator;
+using Microsoft.Extensions.Logging;
+using System.Text.Json;
+
+namespace ReplayGenerator.Domain;
+
+public class ReplayFileBuilder
+{
+	private readonly HttpClient _httpClient;
+	private readonly ILogger<ReplayFileBuilder> _logger;
+	private readonly string? _internalApiUrl;
+
+	public ReplayFileBuilder(HttpClient httpClient, ILogger<ReplayFileBuilder> logger, string? internalApiUrl = null)
+	{
+		_httpClient = httpClient;
+		_logger = logger;
+		_internalApiUrl = internalApiUrl;
+	}
+
+	/// <summary>
+	/// 指定期間の強震モニタ画像と EEW JSON を取得してリプレイファイルを組み立てる
+	/// </summary>
+	public async Task<(byte[] FileBytes, string FileName)> BuildAsync(DateTime startTime, DateTime endTime, string? snapshotJson = null)
+	{
+		var data = new List<ReplayData>();
+		var current = new DateTime(startTime.Year, startTime.Month, startTime.Day, startTime.Hour, startTime.Minute, startTime.Second, DateTimeKind.Utc);
+
+		while (current <= endTime)
+		{
+			try
+			{
+				var imageData = await FetchKyoshinImageAsync(current);
+				if (imageData != null)
+				{
+					data.Add(new KyoshinMonitorImageReplayData
+					{
+						Time = current,
+						Images = new Dictionary<KyoshinMonitorImageReplayData.ImageType, byte[]>
+						{
+							[KyoshinMonitorImageReplayData.ImageType.Shindo] = imageData,
+						},
+					});
+				}
+
+				var eewJsonResult = await FetchKyoshinEewJsonAsync(current);
+				if (eewJsonResult != null)
+				{
+					data.Add(new KyoshinMonitorEewJsonReplayData
+					{
+						Time = current,
+						Json = eewJsonResult,
+					});
+				}
+			}
+			catch (Exception ex)
+			{
+				_logger.LogWarning($"強震モニタデータの取得に失敗しました: {current:HH:mm:ss} - {ex.Message}");
+			}
+
+			current = current.AddSeconds(1);
+		}
+
+		if (snapshotJson != null)
+			InjectEewsFromSnapshot(data, snapshotJson, startTime, endTime);
+
+		data.Sort((a, b) => a.Time.CompareTo(b.Time));
+
+		var fileName = $"{startTime:yyyyMMdd_HHmmss}_{endTime:HHmmss}.eqrp";
+		var fileBytes = await PackReplayFile(data, startTime, endTime);
+
+		_logger.LogInformation($"リプレイファイルを生成しました: {fileName} ({data.Count} データ, {fileBytes.Length} bytes)");
+		return (fileBytes, fileName);
+	}
+
+	private void InjectEewsFromSnapshot(List<ReplayData> data, string snapshotJson, DateTime startTime, DateTime endTime)
+	{
+		try
+		{
+			using var doc = JsonDocument.Parse(snapshotJson);
+			if (!doc.RootElement.TryGetProperty("eews", out var eews))
+				return;
+
+			foreach (var eew in eews.EnumerateArray())
+			{
+				if (!eew.TryGetProperty("reportTime", out var reportTimeProp))
+					continue;
+				if (!DateTime.TryParse(reportTimeProp.GetString(), System.Globalization.CultureInfo.InvariantCulture, System.Globalization.DateTimeStyles.RoundtripKind, out var reportTime))
+					continue;
+				if (reportTime < startTime || reportTime > endTime)
+					continue;
+
+				data.Add(new EqMonitorEewReplayData
+				{
+					Time = reportTime,
+					Json = eew.GetRawText(),
+				});
+			}
+		}
+		catch (Exception ex)
+		{
+			_logger.LogWarning($"EEWスナップショットの注入に失敗しました: {ex.Message}");
+		}
+	}
+
+	private async Task<byte[]?> FetchKyoshinImageAsync(DateTime time)
+	{
+		var url = WebApiUrlGenerator.Generate(WebApiUrlType.RealtimeImg, time, RealtimeDataType.Shindo, false);
+		try
+		{
+			var response = await _httpClient.GetAsync(url);
+			if (!response.IsSuccessStatusCode) return null;
+			return await response.Content.ReadAsByteArrayAsync();
+		}
+		catch
+		{
+			return null;
+		}
+	}
+
+	private async Task<string?> FetchKyoshinEewJsonAsync(DateTime time)
+	{
+		var url = WebApiUrlGenerator.Generate(WebApiUrlType.EewJson, time);
+		try
+		{
+			var response = await _httpClient.GetAsync(url);
+			if (!response.IsSuccessStatusCode) return null;
+			return await response.Content.ReadAsStringAsync();
+		}
+		catch
+		{
+			return null;
+		}
+	}
+
+	private static async Task<byte[]> PackReplayFile(List<ReplayData> data, DateTime startTime, DateTime endTime)
+	{
+		using var ms = new MemoryStream();
+		var reader = new KyoshinReplayFileReader(ms);
+
+		var header = new ReplayFileHeader
+		{
+			SoftwareName = "EQMonitor-ReplayGenerator",
+			StartTime = startTime,
+			EndTime = endTime,
+			CompressionMode = ReplayFileCompressionMode.GZip,
+		};
+
+		await reader.WriteHeader(header);
+		await reader.WriteData(data.ToArray(), ReplayFileCompressionMode.GZip);
+
+		return ms.ToArray();
+	}
+}

--- a/src/Services/ReplayGenerator/Infrastructure/ObjectStorageClient.cs
+++ b/src/Services/ReplayGenerator/Infrastructure/ObjectStorageClient.cs
@@ -1,0 +1,44 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Amazon.S3;
+using Amazon.S3.Model;
+using Microsoft.Extensions.Logging;
+
+namespace ReplayGenerator.Infrastructure;
+
+public class ObjectStorageClient
+{
+	private readonly AmazonS3Client _client;
+	private readonly string _bucket;
+	private readonly ILogger<ObjectStorageClient> _logger;
+
+	public ObjectStorageClient(string endpoint, string accessKey, string secretKey, string bucket, ILogger<ObjectStorageClient> logger)
+	{
+		_bucket = bucket;
+		_logger = logger;
+
+		var config = new AmazonS3Config
+		{
+			ServiceURL = endpoint,
+			ForcePathStyle = true,
+		};
+		_client = new AmazonS3Client(accessKey, secretKey, config);
+	}
+
+	public async Task<long> UploadAsync(string key, Stream stream)
+	{
+		var request = new PutObjectRequest
+		{
+			BucketName = _bucket,
+			Key = key,
+			InputStream = stream,
+			ContentType = "application/octet-stream",
+		};
+		await _client.PutObjectAsync(request);
+
+		var length = stream.Length;
+		_logger.LogInformation($"オブジェクトストレージにアップロード完了: {key} ({length} bytes)");
+		return length;
+	}
+}

--- a/src/Services/ReplayGenerator/Infrastructure/ReplayRepository.cs
+++ b/src/Services/ReplayGenerator/Infrastructure/ReplayRepository.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Npgsql;
+
+namespace ReplayGenerator.Infrastructure;
+
+public class ReplayRepository
+{
+	private readonly string _connectionString;
+	private readonly ILogger<ReplayRepository> _logger;
+
+	public ReplayRepository(string connectionString, ILogger<ReplayRepository> logger)
+	{
+		_connectionString = connectionString;
+		_logger = logger;
+	}
+
+	public async Task<string> InsertReplayFile(DateTime startTime, DateTime endTime, string objectKey, int? fileSizeBytes)
+	{
+		var id = Guid.NewGuid().ToString();
+		await using var conn = new NpgsqlConnection(_connectionString);
+		await conn.OpenAsync();
+
+		await using var cmd = new NpgsqlCommand(
+			"INSERT INTO replay_files (id, start_time, end_time, object_key, file_size_bytes, created_at) VALUES (@id, @start, @end, @key, @size, NOW())",
+			conn);
+		cmd.Parameters.AddWithValue("id", Guid.Parse(id));
+		cmd.Parameters.AddWithValue("start", startTime);
+		cmd.Parameters.AddWithValue("end", endTime);
+		cmd.Parameters.AddWithValue("key", objectKey);
+		cmd.Parameters.AddWithValue("size", (object?)fileSizeBytes ?? DBNull.Value);
+
+		await cmd.ExecuteNonQueryAsync();
+		_logger.LogInformation($"リプレイファイルをDBに登録しました: {id}");
+		return id;
+	}
+
+	public async Task InsertTrigger(string replayFileId, string triggerType, string eventId)
+	{
+		await using var conn = new NpgsqlConnection(_connectionString);
+		await conn.OpenAsync();
+
+		await using var cmd = new NpgsqlCommand(
+			"INSERT INTO replay_file_triggers (id, replay_file_id, trigger_type, event_id, created_at) VALUES (gen_random_uuid(), @fileId, @type, @eventId, NOW()) ON CONFLICT DO NOTHING",
+			conn);
+		cmd.Parameters.AddWithValue("fileId", Guid.Parse(replayFileId));
+		cmd.Parameters.AddWithValue("type", triggerType);
+		cmd.Parameters.AddWithValue("eventId", eventId);
+
+		await cmd.ExecuteNonQueryAsync();
+	}
+}

--- a/src/Services/ReplayGenerator/Infrastructure/ValkeyStateManager.cs
+++ b/src/Services/ReplayGenerator/Infrastructure/ValkeyStateManager.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using ReplayGenerator.Models;
+using StackExchange.Redis;
+
+namespace ReplayGenerator.Infrastructure;
+
+public class ValkeyStateManager
+{
+	private readonly IConnectionMultiplexer _redis;
+	private readonly ILogger<ValkeyStateManager> _logger;
+
+	public ValkeyStateManager(IConnectionMultiplexer redis, ILogger<ValkeyStateManager> logger)
+	{
+		_redis = redis;
+		_logger = logger;
+	}
+
+	private IDatabase Db => _redis.GetDatabase();
+
+	public async Task<bool> TryAcquireLock(string type, string eventId, TimeSpan expiry)
+	{
+		var key = $"replay:lock:{type}:{eventId}";
+		return await Db.StringSetAsync(key, "1", expiry, When.NotExists);
+	}
+
+	public async Task ReleaseLock(string type, string eventId)
+	{
+		var key = $"replay:lock:{type}:{eventId}";
+		await Db.KeyDeleteAsync(key);
+	}
+
+	public async Task SaveShakeState(ShakeState state)
+	{
+		var key = "replay:active:shake";
+		var entries = new HashEntry[]
+		{
+			new("shakeEventId", state.ShakeEventId),
+			new("startTime", state.StartTime.ToString("O")),
+			new("lastEventTime", state.LastEventTime.ToString("O")),
+			new("eewJson", state.EewJson ?? ""),
+			new("status", state.Status.ToString()),
+		};
+		await Db.HashSetAsync(key, entries);
+	}
+
+	public async Task<ShakeState?> LoadShakeState()
+	{
+		var key = "replay:active:shake";
+		var entries = await Db.HashGetAllAsync(key);
+		if (entries.Length == 0) return null;
+
+		var dict = entries.ToDictionary(e => e.Name.ToString(), e => e.Value.ToString());
+		return new ShakeState
+		{
+			ShakeEventId = dict.GetValueOrDefault("shakeEventId", ""),
+			StartTime = DateTime.TryParse(dict.GetValueOrDefault("startTime"), out var st) ? st : DateTime.UtcNow,
+			LastEventTime = DateTime.TryParse(dict.GetValueOrDefault("lastEventTime"), out var let2) ? let2 : DateTime.UtcNow,
+			EewJson = dict.GetValueOrDefault("eewJson") is { Length: > 0 } eew ? eew : null,
+			Status = Enum.TryParse<SessionStatus>(dict.GetValueOrDefault("status"), out var s) ? s : SessionStatus.Tracking,
+		};
+	}
+
+	public async Task ClearShakeState()
+	{
+		await Db.KeyDeleteAsync("replay:active:shake");
+	}
+
+	public async Task SaveEarthquakeState(EarthquakeState state)
+	{
+		var key = $"replay:active:earthquake:{state.EventId}";
+		var entries = new HashEntry[]
+		{
+			new("eventId", state.EventId),
+			new("originTime", state.OriginTime?.ToString("O") ?? ""),
+			new("reportTime", state.ReportTime.ToString("O")),
+			new("hypocenterJson", state.HypocenterJson ?? ""),
+			new("status", state.Status.ToString()),
+		};
+		await Db.HashSetAsync(key, entries);
+		await Db.KeyExpireAsync(key, TimeSpan.FromHours(1));
+	}
+
+	public async Task ClearEarthquakeState(string eventId)
+	{
+		await Db.KeyDeleteAsync($"replay:active:earthquake:{eventId}");
+	}
+
+	public async Task<List<EarthquakeState>> LoadAllEarthquakeStates()
+	{
+		var server = _redis.GetServers().First();
+		var keys = server.Keys(pattern: "replay:active:earthquake:*").ToArray();
+		var states = new List<EarthquakeState>();
+
+		foreach (var key in keys)
+		{
+			var entries = await Db.HashGetAllAsync(key);
+			if (entries.Length == 0) continue;
+
+			var dict = entries.ToDictionary(e => e.Name.ToString(), e => e.Value.ToString());
+			states.Add(new EarthquakeState
+			{
+				EventId = dict.GetValueOrDefault("eventId", ""),
+				OriginTime = DateTime.TryParse(dict.GetValueOrDefault("originTime"), out var ot) ? ot : null,
+				ReportTime = DateTime.TryParse(dict.GetValueOrDefault("reportTime"), out var rt) ? rt : DateTime.UtcNow,
+				HypocenterJson = dict.GetValueOrDefault("hypocenterJson") is { Length: > 0 } h ? h : null,
+				Status = Enum.TryParse<SessionStatus>(dict.GetValueOrDefault("status"), out var s) ? s : SessionStatus.Tracking,
+			});
+		}
+
+		return states;
+	}
+
+	/// <summary>
+	/// Valkey の realtime:snapshot:v2 キーからスナップショットを取得
+	/// </summary>
+	public async Task<string?> GetRealtimeSnapshot()
+	{
+		return await Db.StringGetAsync("realtime:snapshot:v2");
+	}
+}

--- a/src/Services/ReplayGenerator/Models/EarthquakeState.cs
+++ b/src/Services/ReplayGenerator/Models/EarthquakeState.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace ReplayGenerator.Models;
+
+public class EarthquakeState
+{
+	public string EventId { get; set; } = "";
+	public DateTime? OriginTime { get; set; }
+	public DateTime ReportTime { get; set; }
+	public string? HypocenterJson { get; set; }
+	public SessionStatus Status { get; set; } = SessionStatus.Tracking;
+}

--- a/src/Services/ReplayGenerator/Models/ShakeState.cs
+++ b/src/Services/ReplayGenerator/Models/ShakeState.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace ReplayGenerator.Models;
+
+public class ShakeState
+{
+	public string ShakeEventId { get; set; } = "";
+	public DateTime StartTime { get; set; }
+	public DateTime LastEventTime { get; set; }
+	public string? EewJson { get; set; }
+	public SessionStatus Status { get; set; } = SessionStatus.Tracking;
+}

--- a/src/Services/ReplayGenerator/Models/TriggerType.cs
+++ b/src/Services/ReplayGenerator/Models/TriggerType.cs
@@ -1,0 +1,15 @@
+namespace ReplayGenerator.Models;
+
+public enum TriggerType
+{
+	ShakeDetection,
+	Earthquake,
+}
+
+public enum SessionStatus
+{
+	Tracking,
+	Waiting,
+	Generating,
+	Done,
+}

--- a/src/Services/ReplayGenerator/Program.cs
+++ b/src/Services/ReplayGenerator/Program.cs
@@ -1,0 +1,44 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using ReplayGenerator.Domain;
+using ReplayGenerator.Infrastructure;
+using ReplayGenerator.Services;
+using StackExchange.Redis;
+
+var builder = Host.CreateApplicationBuilder(args);
+
+var redisUrl = Environment.GetEnvironmentVariable("REDIS_URL") ?? "localhost:6379";
+var databaseUrl = Environment.GetEnvironmentVariable("DATABASE_URL") ?? "";
+var s3Endpoint = Environment.GetEnvironmentVariable("S3_ENDPOINT") ?? "";
+var s3Bucket = Environment.GetEnvironmentVariable("S3_BUCKET") ?? "eqmonitor-replay";
+var s3AccessKey = Environment.GetEnvironmentVariable("S3_ACCESS_KEY") ?? "";
+var s3SecretKey = Environment.GetEnvironmentVariable("S3_SECRET_KEY") ?? "";
+var internalApiUrl = Environment.GetEnvironmentVariable("EQMONITOR_INTERNAL_API_URL");
+
+builder.Services.AddSingleton<IConnectionMultiplexer>(_ => ConnectionMultiplexer.Connect(redisUrl));
+builder.Services.AddSingleton<ValkeyStateManager>();
+builder.Services.AddSingleton<ShakeDetectionTracker>();
+builder.Services.AddSingleton<EarthquakeTracker>();
+builder.Services.AddSingleton(_ =>
+{
+	var logger = _.GetRequiredService<ILogger<ReplayRepository>>();
+	return new ReplayRepository(databaseUrl, logger);
+});
+builder.Services.AddSingleton(sp =>
+{
+	var logger = sp.GetRequiredService<ILogger<ObjectStorageClient>>();
+	return new ObjectStorageClient(s3Endpoint, s3AccessKey, s3SecretKey, s3Bucket, logger);
+});
+builder.Services.AddHttpClient();
+builder.Services.AddSingleton(sp =>
+{
+	var httpClientFactory = sp.GetRequiredService<IHttpClientFactory>();
+	var logger = sp.GetRequiredService<ILogger<ReplayFileBuilder>>();
+	return new ReplayFileBuilder(httpClientFactory.CreateClient(), logger, internalApiUrl);
+});
+
+builder.Services.AddHostedService<ReplayGeneratorWorker>();
+
+var host = builder.Build();
+await host.RunAsync();

--- a/src/Services/ReplayGenerator/ReplayGenerator.csproj
+++ b/src/Services/ReplayGenerator/ReplayGenerator.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk.Worker">
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <LangVersion>latest</LangVersion>
+        <Nullable>enable</Nullable>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <RootNamespace>ReplayGenerator</RootNamespace>
+        <OutputType>Exe</OutputType>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="../../KyoshinEewViewer.Core/KyoshinEewViewer.Core.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
+        <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.5" />
+        <PackageReference Include="StackExchange.Redis" Version="2.8.41" />
+        <PackageReference Include="Npgsql" Version="9.0.3" />
+        <PackageReference Include="AWSSDK.S3" Version="4.0.0.3" />
+        <PackageReference Include="KyoshinMonitorLib" Version="0.4.5.2" />
+        <PackageReference Include="KyoshinMonitorLib.SkiaImages" Version="0.4.5.2" />
+    </ItemGroup>
+</Project>

--- a/src/Services/ReplayGenerator/Services/EarthquakeTracker.cs
+++ b/src/Services/ReplayGenerator/Services/EarthquakeTracker.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using ReplayGenerator.Infrastructure;
+using ReplayGenerator.Models;
+
+namespace ReplayGenerator.Services;
+
+public class EarthquakeTracker
+{
+	private readonly ValkeyStateManager _state;
+	private readonly ILogger<EarthquakeTracker> _logger;
+
+	public EarthquakeTracker(ValkeyStateManager state, ILogger<EarthquakeTracker> logger)
+	{
+		_state = state;
+		_logger = logger;
+	}
+
+	/// <summary>
+	/// 地震情報メッセージを受信した際の処理。
+	/// 戻り値が非 null の場合はリプレイファイル生成を開始する。
+	/// </summary>
+	public async Task<EarthquakeState?> OnEarthquakeUpsert(string eventId, string recordJson)
+	{
+		var acquired = await _state.TryAcquireLock("earthquake", eventId, TimeSpan.FromMinutes(10));
+		if (!acquired)
+		{
+			_logger.LogDebug($"地震情報のロック取得失敗（重複）: {eventId}");
+			return null;
+		}
+
+		DateTime? originTime = null;
+		var reportTime = DateTime.UtcNow;
+
+		try
+		{
+			using var doc = JsonDocument.Parse(recordJson);
+			if (doc.RootElement.TryGetProperty("originTime", out var ot) && DateTime.TryParse(ot.GetString(), out var parsed))
+				originTime = parsed;
+			if (doc.RootElement.TryGetProperty("reportTime", out var rt) && DateTime.TryParse(rt.GetString(), out var parsedRt))
+				reportTime = parsedRt;
+		}
+		catch { }
+
+		var state = new EarthquakeState
+		{
+			EventId = eventId,
+			OriginTime = originTime,
+			ReportTime = reportTime,
+			HypocenterJson = recordJson,
+			Status = SessionStatus.Generating,
+		};
+
+		await _state.SaveEarthquakeState(state);
+		_logger.LogInformation($"地震情報トリガー: {eventId}");
+		return state;
+	}
+
+	public async Task CompleteAsync(string eventId)
+	{
+		await _state.ReleaseLock("earthquake", eventId);
+		await _state.ClearEarthquakeState(eventId);
+	}
+}

--- a/src/Services/ReplayGenerator/Services/ReplayGeneratorWorker.cs
+++ b/src/Services/ReplayGenerator/Services/ReplayGeneratorWorker.cs
@@ -1,0 +1,190 @@
+using System;
+using System.IO;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using ReplayGenerator.Domain;
+using ReplayGenerator.Infrastructure;
+using ReplayGenerator.Models;
+using StackExchange.Redis;
+
+namespace ReplayGenerator.Services;
+
+public class ReplayGeneratorWorker : BackgroundService
+{
+	private readonly ILogger<ReplayGeneratorWorker> _logger;
+	private readonly IConnectionMultiplexer _redis;
+	private readonly ValkeyStateManager _stateManager;
+	private readonly ShakeDetectionTracker _shakeTracker;
+	private readonly EarthquakeTracker _earthquakeTracker;
+	private readonly ReplayFileBuilder _replayBuilder;
+	private readonly ObjectStorageClient _storageClient;
+	private readonly ReplayRepository _repository;
+
+	private const string PubSubChannel = "realtime:broadcast:v1";
+
+	public ReplayGeneratorWorker(
+		ILogger<ReplayGeneratorWorker> logger,
+		IConnectionMultiplexer redis,
+		ValkeyStateManager stateManager,
+		ShakeDetectionTracker shakeTracker,
+		EarthquakeTracker earthquakeTracker,
+		ReplayFileBuilder replayBuilder,
+		ObjectStorageClient storageClient,
+		ReplayRepository repository)
+	{
+		_logger = logger;
+		_redis = redis;
+		_stateManager = stateManager;
+		_shakeTracker = shakeTracker;
+		_earthquakeTracker = earthquakeTracker;
+		_replayBuilder = replayBuilder;
+		_storageClient = storageClient;
+		_repository = repository;
+	}
+
+	protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+	{
+		_logger.LogInformation("ReplayGenerator ワーカー開始");
+
+		await _shakeTracker.RestoreAsync();
+
+		var subscriber = _redis.GetSubscriber();
+		await subscriber.SubscribeAsync(RedisChannel.Literal(PubSubChannel), async (_, message) =>
+		{
+			if (stoppingToken.IsCancellationRequested) return;
+			try
+			{
+				await ProcessMessage(message!);
+			}
+			catch (Exception ex)
+			{
+				_logger.LogWarning($"Pub/Sub メッセージ処理エラー: {ex.Message}");
+			}
+		});
+
+		_logger.LogInformation("Pub/Sub 購読開始");
+
+		while (!stoppingToken.IsCancellationRequested)
+		{
+			try
+			{
+				var snapshot = await _stateManager.GetRealtimeSnapshot();
+				var (shouldGenerate, state) = await _shakeTracker.CheckTimerAsync(snapshot);
+				if (shouldGenerate && state != null)
+					await GenerateFromShake(state, snapshot);
+			}
+			catch (Exception ex)
+			{
+				_logger.LogWarning($"タイマーチェックエラー: {ex.Message}");
+			}
+
+			await Task.Delay(1000, stoppingToken);
+		}
+
+		await subscriber.UnsubscribeAsync(RedisChannel.Literal(PubSubChannel));
+		_logger.LogInformation("ReplayGenerator ワーカー停止");
+	}
+
+	private async Task ProcessMessage(string message)
+	{
+		using var doc = JsonDocument.Parse(message);
+		var root = doc.RootElement;
+
+		if (!root.TryGetProperty("type", out var typeProp))
+			return;
+
+		var type = typeProp.GetString();
+
+		switch (type)
+		{
+			case "shake_detected":
+				if (root.TryGetProperty("eventId", out var shakeEventId))
+					await _shakeTracker.OnShakeDetected(shakeEventId.GetString()!);
+				break;
+
+			case "EEW":
+				if (root.TryGetProperty("event", out var eewEvent))
+				{
+					var snapshot = await _stateManager.GetRealtimeSnapshot();
+					if (snapshot != null)
+						await _shakeTracker.SetEewSnapshot(snapshot);
+				}
+				break;
+
+			case "earthquake":
+				if (root.TryGetProperty("operation", out var op) && op.GetString() == "upsert"
+					&& root.TryGetProperty("event_id", out var eqEventId))
+				{
+					var recordJson = root.TryGetProperty("record", out var record) ? record.GetRawText() : "{}";
+					var eqState = await _earthquakeTracker.OnEarthquakeUpsert(eqEventId.GetString()!, recordJson);
+					if (eqState != null)
+						await GenerateFromEarthquake(eqState);
+				}
+				break;
+		}
+	}
+
+	private async Task GenerateFromShake(ShakeState state, string? snapshotJson)
+	{
+		_logger.LogInformation($"揺れ検知リプレイファイル生成開始: {state.ShakeEventId}");
+
+		try
+		{
+			var startTime = state.StartTime.AddSeconds(-10);
+			var endTime = state.LastEventTime.AddSeconds(5);
+
+			var (fileBytes, fileName) = await _replayBuilder.BuildAsync(startTime, endTime, snapshotJson);
+
+			using var stream = new MemoryStream(fileBytes);
+			var objectKey = $"replay/{fileName}";
+			var size = await _storageClient.UploadAsync(objectKey, stream);
+
+			var replayFileId = await _repository.InsertReplayFile(startTime, endTime, objectKey, (int)size);
+			await _repository.InsertTrigger(replayFileId, "shake_detection", state.ShakeEventId);
+
+			_logger.LogInformation($"揺れ検知リプレイファイル生成完了: {fileName}");
+		}
+		catch (Exception ex)
+		{
+			_logger.LogWarning($"揺れ検知リプレイファイル生成エラー: {ex.Message}");
+		}
+		finally
+		{
+			await _shakeTracker.CompleteAsync();
+		}
+	}
+
+	private async Task GenerateFromEarthquake(EarthquakeState state)
+	{
+		_logger.LogInformation($"地震情報リプレイファイル生成開始: {state.EventId}");
+
+		try
+		{
+			var startTime = (state.OriginTime ?? state.ReportTime).AddSeconds(-30);
+			var endTime = state.ReportTime.AddSeconds(30);
+
+			var snapshotJson = await _stateManager.GetRealtimeSnapshot();
+			var (fileBytes, fileName) = await _replayBuilder.BuildAsync(startTime, endTime, snapshotJson);
+
+			using var stream = new MemoryStream(fileBytes);
+			var objectKey = $"replay/{fileName}";
+			var size = await _storageClient.UploadAsync(objectKey, stream);
+
+			var replayFileId = await _repository.InsertReplayFile(startTime, endTime, objectKey, (int)size);
+			await _repository.InsertTrigger(replayFileId, "earthquake", state.EventId);
+
+			_logger.LogInformation($"地震情報リプレイファイル生成完了: {fileName}");
+		}
+		catch (Exception ex)
+		{
+			_logger.LogWarning($"地震情報リプレイファイル生成エラー: {ex.Message}");
+		}
+		finally
+		{
+			await _earthquakeTracker.CompleteAsync(state.EventId);
+		}
+	}
+}

--- a/src/Services/ReplayGenerator/Services/ShakeDetectionTracker.cs
+++ b/src/Services/ReplayGenerator/Services/ShakeDetectionTracker.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using ReplayGenerator.Infrastructure;
+using ReplayGenerator.Models;
+
+namespace ReplayGenerator.Services;
+
+public class ShakeDetectionTracker
+{
+	private readonly ValkeyStateManager _state;
+	private readonly ILogger<ShakeDetectionTracker> _logger;
+
+	private ShakeState? _current;
+	private DateTime? _waitUntil;
+
+	public ShakeDetectionTracker(ValkeyStateManager state, ILogger<ShakeDetectionTracker> logger)
+	{
+		_state = state;
+		_logger = logger;
+	}
+
+	/// <summary>
+	/// 再起動時に Valkey から状態を復元する
+	/// </summary>
+	public async Task RestoreAsync()
+	{
+		_current = await _state.LoadShakeState();
+		if (_current != null)
+			_logger.LogInformation($"揺れ検知セッションを復元しました: {_current.ShakeEventId} (status={_current.Status})");
+	}
+
+	/// <summary>
+	/// shake_detected メッセージを受信した際の処理
+	/// </summary>
+	public async Task<bool> OnShakeDetected(string eventId)
+	{
+		if (_current != null && _current.ShakeEventId == eventId)
+		{
+			_current.LastEventTime = DateTime.UtcNow;
+			_current.Status = SessionStatus.Tracking;
+			_waitUntil = null;
+			await _state.SaveShakeState(_current);
+			return false;
+		}
+
+		if (_current != null)
+			return false;
+
+		var acquired = await _state.TryAcquireLock("shake", eventId, TimeSpan.FromMinutes(10));
+		if (!acquired)
+			return false;
+
+		_current = new ShakeState
+		{
+			ShakeEventId = eventId,
+			StartTime = DateTime.UtcNow,
+			LastEventTime = DateTime.UtcNow,
+			Status = SessionStatus.Tracking,
+		};
+		await _state.SaveShakeState(_current);
+		_logger.LogInformation($"揺れ検知トラッキング開始: {eventId}");
+		return true;
+	}
+
+	/// <summary>
+	/// EEW 情報を関連付ける
+	/// </summary>
+	public async Task SetEewSnapshot(string eewJson)
+	{
+		if (_current == null) return;
+		_current.EewJson = eewJson;
+		await _state.SaveShakeState(_current);
+	}
+
+	/// <summary>
+	/// 1秒ごとのタイマーで揺れ終了を判定する。
+	/// 戻り値が true の場合はリプレイファイル生成を開始する。
+	/// </summary>
+	public async Task<(bool ShouldGenerate, ShakeState? State)> CheckTimerAsync(string? snapshotJson)
+	{
+		if (_current == null)
+			return (false, null);
+
+		if (_current.Status == SessionStatus.Tracking)
+		{
+			var elapsed = DateTime.UtcNow - _current.LastEventTime;
+			if (elapsed < TimeSpan.FromSeconds(30))
+				return (false, null);
+
+			_current.Status = SessionStatus.Waiting;
+
+			var waitSeconds = DetermineWaitSeconds(snapshotJson);
+			_waitUntil = DateTime.UtcNow.AddSeconds(waitSeconds);
+			_logger.LogInformation($"揺れ終了検知、{waitSeconds}秒待機開始: {_current.ShakeEventId}");
+			await _state.SaveShakeState(_current);
+			return (false, null);
+		}
+
+		if (_current.Status == SessionStatus.Waiting && _waitUntil.HasValue && DateTime.UtcNow >= _waitUntil.Value)
+		{
+			_current.Status = SessionStatus.Generating;
+			await _state.SaveShakeState(_current);
+			return (true, _current);
+		}
+
+		return (false, null);
+	}
+
+	/// <summary>
+	/// 生成完了後のクリーンアップ
+	/// </summary>
+	public async Task CompleteAsync()
+	{
+		if (_current == null) return;
+		await _state.ReleaseLock("shake", _current.ShakeEventId);
+		await _state.ClearShakeState();
+		_current = null;
+		_waitUntil = null;
+	}
+
+	private int DetermineWaitSeconds(string? snapshotJson)
+	{
+		if (snapshotJson == null) return 30;
+
+		try
+		{
+			using var doc = JsonDocument.Parse(snapshotJson);
+			if (!doc.RootElement.TryGetProperty("eews", out var eews))
+				return 30;
+
+			foreach (var eew in eews.EnumerateArray())
+			{
+				if (eew.TryGetProperty("hypocenter", out var hypo) && hypo.TryGetProperty("depth", out var depthProp))
+				{
+					var depth = depthProp.GetInt32();
+					var magnitude = eew.TryGetProperty("magnitude", out var magProp) ? magProp.GetDouble() : 0;
+
+					if (depth <= 150 && magnitude <= 5)
+						return 60;
+					return 180;
+				}
+			}
+		}
+		catch { }
+
+		return 30;
+	}
+}

--- a/src/Tools/EarthquakeReplayFilePacker/Program.cs
+++ b/src/Tools/EarthquakeReplayFilePacker/Program.cs
@@ -31,6 +31,7 @@ async Task OpenFile()
 			"強震モニタの画像を期間指定で自動取得",
 			"強震モニタをリアルタイム受信",
 			"dmdataのEEW電文自動組み込み",
+			"EQMonitorのEEWペイロードを自動注入",
 			//"JmaXmlTelegramReplayData",
 			//"SNPLogEntryReplayData",
 			//"AxisJsonReplayData",
@@ -77,6 +78,9 @@ async Task OpenFile()
 				break;
 			case "dmdataのEEW電文自動組み込み":
 				await ImportDmdataEewTelegram(data);
+				break;
+			case "EQMonitorのEEWペイロードを自動注入":
+				await ImportEqMonitorEew(data);
 				break;
 			case "JmaXmlTelegramReplayData":
 				var xmlPath = Prompt.Input<string>("XML ファイルパスを入力してください");
@@ -1085,4 +1089,88 @@ void CreateTestData(List<ReplayData> data)
 			},
 		}),
 	});
+}
+
+async Task ImportEqMonitorEew(List<ReplayData> data)
+{
+	var apiUrl = Prompt.Input<string>("EQMonitor 内部API URLを入力してください (例: http://localhost:8788)");
+
+	if (data.Count == 0)
+	{
+		Console.WriteLine("データがありません。先にファイルを読み込んでください。");
+		return;
+	}
+
+	var minTime = data.Min(d => d.Time);
+	var maxTime = data.Max(d => d.Time);
+	Console.WriteLine($"データの時間範囲: {minTime:yyyy/MM/dd HH:mm:ss} ～ {maxTime:yyyy/MM/dd HH:mm:ss}");
+
+	using var httpClient = new HttpClient();
+
+	Console.WriteLine("EQMonitor 内部API からリアルタイム状態を取得しています...");
+	var response = await httpClient.GetAsync($"{apiUrl.TrimEnd('/')}/internal/realtime/state");
+	if (!response.IsSuccessStatusCode)
+	{
+		Console.WriteLine($"API エラー: {response.StatusCode}");
+		return;
+	}
+
+	var json = await response.Content.ReadAsStringAsync();
+	using var doc = JsonDocument.Parse(json);
+	var root = doc.RootElement;
+
+	if (!root.TryGetProperty("eews", out var eewsElement))
+	{
+		Console.WriteLine("EEW データが見つかりません");
+		return;
+	}
+
+	var injectedCount = 0;
+	var skippedCount = 0;
+
+	var existingKeys = new HashSet<string>();
+	foreach (var d in data)
+	{
+		if (d is EqMonitorEewReplayData existing)
+		{
+			using var existingDoc = JsonDocument.Parse(existing.Json);
+			var existingRoot = existingDoc.RootElement;
+			if (existingRoot.TryGetProperty("eventId", out var eid) && existingRoot.TryGetProperty("serialNo", out var sno))
+				existingKeys.Add($"{eid.GetString()}_{sno.GetInt32()}");
+		}
+	}
+
+	foreach (var eew in eewsElement.EnumerateArray())
+	{
+		if (!eew.TryGetProperty("reportTime", out var reportTimeProp))
+			continue;
+
+		if (!DateTime.TryParse(reportTimeProp.GetString(), System.Globalization.CultureInfo.InvariantCulture, System.Globalization.DateTimeStyles.RoundtripKind, out var reportTime))
+			continue;
+
+		if (reportTime < minTime || reportTime > maxTime)
+			continue;
+
+		var eventId = eew.TryGetProperty("eventId", out var eidProp) ? eidProp.GetString() ?? "" : "";
+		var serialNo = eew.TryGetProperty("serialNo", out var snoProp) ? snoProp.GetInt32() : 0;
+		var key = $"{eventId}_{serialNo}";
+
+		if (existingKeys.Contains(key))
+		{
+			skippedCount++;
+			continue;
+		}
+
+		data.Add(new EqMonitorEewReplayData
+		{
+			Time = reportTime,
+			Json = eew.GetRawText(),
+		});
+		existingKeys.Add(key);
+		injectedCount++;
+		Console.WriteLine($"  注入: eventId={eventId} serialNo={serialNo} reportTime={reportTime:HH:mm:ss}");
+	}
+
+	Console.WriteLine($"注入完了: {injectedCount}件追加, {skippedCount}件スキップ（重複）");
+	data.Sort((a, b) => a.Time.CompareTo(b.Time));
 }


### PR DESCRIPTION
## 概要

EQMonitor Backend の EventMessage JSON をリプレイファイルに組み込むための型追加と、リプレイファイル自動生成 Worker Service の新設。

### 変更内容

#### EqMonitorEewReplayData (Union 1003)
- ReplayData に [Union(1003, typeof(EqMonitorEewReplayData))] を追加
- 旧クライアントは未知の Union key をスキップするため後方互換

#### ReplayFileEarthquakeInformationHost 更新
- EqMonitorEewReplayData ケースを DataArrived の switch に追加
- EqMonitorEventMessage モデルで EventMessage JSON をデシリアライズ
- EqMonitorEventMessageConverter で EventMessage → C# Eew レコード変換

#### EarthquakeReplayFilePacker CLI 改善
- EQMonitorのEEWペイロードを自動注入メニューを追加
- 内部 API (/internal/realtime/state) 経由でアクセス（外部 URL 不使用）

#### ReplayGenerator Worker Service (新規)
- src/Services/ReplayGenerator/ に .NET Worker Service プロジェクトを新設
- Valkey Pub/Sub 購読、State管理、S3 upload、DB 書き込み