### PR TITLE
chore: PR は YumNumm（origin）のみ — Cursor ルールと CLAUDE 追記

### DIFF
--- a/.cursor/rules/git-pr-yumnumm-only.mdc
+++ b/.cursor/rules/git-pr-yumnumm-only.mdc
@@ -1,0 +1,11 @@
+---
+description: GitHub PR は常に YumNumm（origin）向けのみ。upstream（ingen084）へ PR を作らない
+alwaysApply: true
+---
+
+# Git / GitHub PR（厳守）
+
+- **ingen084/KyoshinEewViewerIngen は upstream** である。ここへ **Pull Request を作成してはならない**。
+- PR は **常に `YumNumm/KyoshinEewViewerIngen`（このリポジトリの `origin`）** に対してのみ作成する。
+- `gh pr create` を使うときは、取り違え防止のため **必ず `--repo YumNumm/KyoshinEewViewerIngen` を明示する**。デフォルトや認証コンテキストに任せない。
+- 実行前に `git remote -v` で `origin` が `YumNumm` を指していることを確認してよい。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,11 @@
 
 **Documentation**: Technical documentation and code structure explanations may be in English for international collaboration, but implementation details should prioritize Japanese.
 
+## GitHub / Pull Requests（厳守）
+
+- **ingen084** のリポジトリは **upstream**。ここへ PR を作成しない。
+- PR は **常に YumNumm（このリポジトリの `origin`）** のみ。`gh pr create` では **`--repo YumNumm/KyoshinEewViewerIngen`** を明示する。
+
 ## Project Overview
 
 **KyoshinEewViewer for ingen** - Japanese disaster prevention application


### PR DESCRIPTION
## 内容

- `.cursor/rules/git-pr-yumnumm-only.mdc`（`alwaysApply: true`）
- `CLAUDE.md` に GitHub / PR の注意書き

upstream（ingen084）へ PR を作らず、常に `YumNumm/KyoshinEewViewerIngen` の `origin` 向けとし、`gh pr create` では `--repo YumNumm/KyoshinEewViewerIngen` を明示する。

## 備考

機能・ReplayGenerator テストなどの変更は含みません（`develop` からルールコミットのみ cherry-pick）。

Made with [Cursor](https://cursor.com)