### PR TITLE
feat(replay-generator): 強震モニタ画像取得に指数バックオフのリトライを追加

### DIFF
--- a/docs/replay-generator-kyoshin-image-retry.md
+++ b/docs/replay-generator-kyoshin-image-retry.md
@@ -1,0 +1,28 @@
+# ReplayGenerator: 強震モニタ画像取得のリトライ
+
+ReplayGenerator がリプレイファイル生成時に取得する強震モニタ画像は、公開遅延により一発で取得失敗するケースがある。これを軽減するため、`ReplayFileBuilder.FetchKyoshinImageAsync` に指数バックオフ付きのリトライを実装している。
+
+## 挙動
+
+- 1 秒ごとのフレームで強震モニタ画像 (`RealtimeImg`/`Shindo`) を取得する
+- 失敗時（HTTP エラー or 例外）は指数バックオフで再試行する
+- `MaxAttempts` を使い切っても取得できなかった場合は **そのフレームをスキップ**（既存挙動の踏襲）
+- スキップ時は `WARNING` ログを出力する（理由: 公開遅延の場合は数秒で復旧することが多く、リプレイファイル生成全体を中断するより欠落フレームとして許容したほうが運用上有利）
+
+## 設定
+
+環境変数で調整できる。
+
+| 環境変数 | デフォルト | 説明 |
+|---|---|---|
+| `KYOSHIN_IMAGE_RETRY_MAX_ATTEMPTS` | `3` | 最大試行回数（初回含む）。`1` でリトライ無し |
+| `KYOSHIN_IMAGE_RETRY_INITIAL_DELAY_MS` | `500` | 初回リトライ前の待機時間 (ms) |
+| `KYOSHIN_IMAGE_RETRY_BACKOFF_FACTOR` | `2.0` | 指数バックオフ倍率 |
+| `KYOSHIN_IMAGE_RETRY_MAX_DELAY_MS` | `5000` | リトライ間の最大待機時間 (ms) |
+
+例: デフォルト設定では `0ms → 500ms → 1000ms` の間隔で計 3 回試行する。
+
+## 適用範囲
+
+- 強震モニタ画像取得 (`FetchKyoshinImageAsync`) のみ対象
+- EEW JSON 取得 (`FetchKyoshinEewJsonAsync`) は今回はリトライ対象外（Issue スコープ外）

--- a/src/Sandboxes/ReplayGenerator/Domain/KyoshinImageRetryOptions.cs
+++ b/src/Sandboxes/ReplayGenerator/Domain/KyoshinImageRetryOptions.cs
@@ -1,0 +1,71 @@
+namespace ReplayGenerator.Domain;
+
+/// <summary>
+/// 強震モニタ画像取得時のリトライ設定
+/// </summary>
+public class KyoshinImageRetryOptions
+{
+	/// <summary>
+	/// 最大試行回数（初回含む）。1 以上を指定する。1 の場合はリトライ無し。
+	/// </summary>
+	public int MaxAttempts { get; init; } = 3;
+
+	/// <summary>
+	/// 初回リトライ前の待機時間
+	/// </summary>
+	public TimeSpan InitialDelay { get; init; } = TimeSpan.FromMilliseconds(500);
+
+	/// <summary>
+	/// 指数バックオフ倍率。1.0 で固定間隔、2.0 で倍々
+	/// </summary>
+	public double BackoffFactor { get; init; } = 2.0;
+
+	/// <summary>
+	/// 各リトライ間の最大待機時間。指数バックオフがこの値を超えた場合はこの値でクランプする。
+	/// </summary>
+	public TimeSpan MaxDelay { get; init; } = TimeSpan.FromSeconds(5);
+
+	/// <summary>
+	/// 環境変数から設定を読み込む
+	/// </summary>
+	public static KyoshinImageRetryOptions FromEnvironment()
+	{
+		return new KyoshinImageRetryOptions
+		{
+			MaxAttempts = ParseInt("KYOSHIN_IMAGE_RETRY_MAX_ATTEMPTS", 3, minValue: 1),
+			InitialDelay = TimeSpan.FromMilliseconds(ParseInt("KYOSHIN_IMAGE_RETRY_INITIAL_DELAY_MS", 500, minValue: 0)),
+			BackoffFactor = ParseDouble("KYOSHIN_IMAGE_RETRY_BACKOFF_FACTOR", 2.0, minValue: 1.0),
+			MaxDelay = TimeSpan.FromMilliseconds(ParseInt("KYOSHIN_IMAGE_RETRY_MAX_DELAY_MS", 5000, minValue: 0)),
+		};
+	}
+
+	/// <summary>
+	/// 指定試行回（0 始まり、0 は初回）の前に挟む待機時間を計算する
+	/// </summary>
+	public TimeSpan GetDelayForAttempt(int attemptIndex)
+	{
+		if (attemptIndex <= 0)
+			return TimeSpan.Zero;
+
+		var ms = InitialDelay.TotalMilliseconds * Math.Pow(BackoffFactor, attemptIndex - 1);
+		if (double.IsInfinity(ms) || ms > MaxDelay.TotalMilliseconds)
+			return MaxDelay;
+		return TimeSpan.FromMilliseconds(ms);
+	}
+
+	private static int ParseInt(string key, int defaultValue, int minValue)
+	{
+		var raw = Environment.GetEnvironmentVariable(key);
+		if (string.IsNullOrEmpty(raw) || !int.TryParse(raw, out var value))
+			return defaultValue;
+		return value < minValue ? minValue : value;
+	}
+
+	private static double ParseDouble(string key, double defaultValue, double minValue)
+	{
+		var raw = Environment.GetEnvironmentVariable(key);
+		if (string.IsNullOrEmpty(raw) || !double.TryParse(raw, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out var value))
+			return defaultValue;
+		return value < minValue ? minValue : value;
+	}
+}

--- a/src/Sandboxes/ReplayGenerator/Domain/ReplayFileBuilder.cs
+++ b/src/Sandboxes/ReplayGenerator/Domain/ReplayFileBuilder.cs
@@ -11,12 +11,14 @@ public class ReplayFileBuilder
 	private readonly HttpClient _httpClient;
 	private readonly ILogger<ReplayFileBuilder> _logger;
 	private readonly string? _internalApiUrl;
+	private readonly KyoshinImageRetryOptions _imageRetryOptions;
 
-	public ReplayFileBuilder(HttpClient httpClient, ILogger<ReplayFileBuilder> logger, string? internalApiUrl = null)
+	public ReplayFileBuilder(HttpClient httpClient, ILogger<ReplayFileBuilder> logger, string? internalApiUrl = null, KyoshinImageRetryOptions? imageRetryOptions = null)
 	{
 		_httpClient = httpClient;
 		_logger = logger;
 		_internalApiUrl = internalApiUrl;
+		_imageRetryOptions = imageRetryOptions ?? new KyoshinImageRetryOptions();
 	}
 
 	/// <summary>
@@ -104,19 +106,44 @@ public class ReplayFileBuilder
 		}
 	}
 
-	private async Task<byte[]?> FetchKyoshinImageAsync(DateTime time)
+	internal async Task<byte[]?> FetchKyoshinImageAsync(DateTime time)
 	{
 		var url = WebApiUrlGenerator.Generate(WebApiUrlType.RealtimeImg, time, RealtimeDataType.Shindo, false);
-		try
+		var maxAttempts = Math.Max(1, _imageRetryOptions.MaxAttempts);
+
+		for (var attempt = 0; attempt < maxAttempts; attempt++)
 		{
-			var response = await _httpClient.GetAsync(url);
-			if (!response.IsSuccessStatusCode) return null;
-			return await response.Content.ReadAsByteArrayAsync();
+			var delay = _imageRetryOptions.GetDelayForAttempt(attempt);
+			if (delay > TimeSpan.Zero)
+				await Task.Delay(delay);
+
+			try
+			{
+				var response = await _httpClient.GetAsync(url);
+				if (response.IsSuccessStatusCode)
+					return await response.Content.ReadAsByteArrayAsync();
+
+				if (attempt + 1 >= maxAttempts)
+				{
+					_logger.LogWarning($"強震モニタ画像の取得に失敗しました（リトライ上限到達）: {time:HH:mm:ss} status={(int)response.StatusCode} attempts={attempt + 1}");
+					return null;
+				}
+
+				_logger.LogDebug($"強震モニタ画像の取得に失敗しリトライします: {time:HH:mm:ss} status={(int)response.StatusCode} attempt={attempt + 1}/{maxAttempts}");
+			}
+			catch (Exception ex)
+			{
+				if (attempt + 1 >= maxAttempts)
+				{
+					_logger.LogWarning(ex, $"強震モニタ画像の取得に失敗しました（リトライ上限到達・例外）: {time:HH:mm:ss} attempts={attempt + 1}");
+					return null;
+				}
+
+				_logger.LogDebug(ex, $"強震モニタ画像の取得で例外が発生しリトライします: {time:HH:mm:ss} attempt={attempt + 1}/{maxAttempts}");
+			}
 		}
-		catch
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	private async Task<string?> FetchKyoshinEewJsonAsync(DateTime time)

--- a/src/Sandboxes/ReplayGenerator/Program.cs
+++ b/src/Sandboxes/ReplayGenerator/Program.cs
@@ -44,11 +44,13 @@ internal class Program
 			return new ObjectStorageClient(s3Endpoint, s3AccessKey, s3SecretKey, s3Bucket, logger);
 		});
 		builder.Services.AddHttpClient();
+		builder.Services.AddSingleton(_ => KyoshinImageRetryOptions.FromEnvironment());
 		builder.Services.AddSingleton(sp =>
 		{
 			var httpClientFactory = sp.GetRequiredService<IHttpClientFactory>();
 			var logger = sp.GetRequiredService<ILogger<ReplayFileBuilder>>();
-			return new ReplayFileBuilder(httpClientFactory.CreateClient(), logger, internalApiUrl);
+			var retryOptions = sp.GetRequiredService<KyoshinImageRetryOptions>();
+			return new ReplayFileBuilder(httpClientFactory.CreateClient(), logger, internalApiUrl, retryOptions);
 		});
 
 		builder.Services.AddHostedService<ReplayGeneratorWorker>();

--- a/src/Sandboxes/ReplayGenerator/ReplayGenerator.csproj
+++ b/src/Sandboxes/ReplayGenerator/ReplayGenerator.csproj
@@ -15,6 +15,10 @@
     </ItemGroup>
 
     <ItemGroup>
+        <InternalsVisibleTo Include="ReplayGenerator.Tests" />
+    </ItemGroup>
+
+    <ItemGroup>
         <PackageReference Include="prometheus-net.AspNetCore" Version="8.2.1" />
         <PackageReference Include="StackExchange.Redis" Version="2.8.41" />
         <PackageReference Include="Npgsql" Version="9.0.3" />

--- a/tests/ReplayGenerator.Tests/KyoshinImageRetryOptionsTests.cs
+++ b/tests/ReplayGenerator.Tests/KyoshinImageRetryOptionsTests.cs
@@ -1,0 +1,48 @@
+using ReplayGenerator.Domain;
+using Xunit;
+
+namespace ReplayGenerator.Tests;
+
+public class KyoshinImageRetryOptionsTests
+{
+	[Fact(DisplayName = "GetDelayForAttempt: 0 回目は待機なし")]
+	public void GetDelayForAttempt_初回は待機なし()
+	{
+		var options = new KyoshinImageRetryOptions
+		{
+			InitialDelay = TimeSpan.FromMilliseconds(500),
+			BackoffFactor = 2.0,
+			MaxDelay = TimeSpan.FromSeconds(5),
+		};
+
+		Assert.Equal(TimeSpan.Zero, options.GetDelayForAttempt(0));
+	}
+
+	[Fact(DisplayName = "GetDelayForAttempt: 指数バックオフで待機時間が増える")]
+	public void GetDelayForAttempt_指数バックオフ()
+	{
+		var options = new KyoshinImageRetryOptions
+		{
+			InitialDelay = TimeSpan.FromMilliseconds(500),
+			BackoffFactor = 2.0,
+			MaxDelay = TimeSpan.FromSeconds(10),
+		};
+
+		Assert.Equal(TimeSpan.FromMilliseconds(500), options.GetDelayForAttempt(1));
+		Assert.Equal(TimeSpan.FromMilliseconds(1000), options.GetDelayForAttempt(2));
+		Assert.Equal(TimeSpan.FromMilliseconds(2000), options.GetDelayForAttempt(3));
+	}
+
+	[Fact(DisplayName = "GetDelayForAttempt: MaxDelay でクランプされる")]
+	public void GetDelayForAttempt_MaxDelayでクランプ()
+	{
+		var options = new KyoshinImageRetryOptions
+		{
+			InitialDelay = TimeSpan.FromMilliseconds(500),
+			BackoffFactor = 10.0,
+			MaxDelay = TimeSpan.FromSeconds(2),
+		};
+
+		Assert.Equal(TimeSpan.FromSeconds(2), options.GetDelayForAttempt(5));
+	}
+}

--- a/tests/ReplayGenerator.Tests/ReplayFileBuilderFetchTests.cs
+++ b/tests/ReplayGenerator.Tests/ReplayFileBuilderFetchTests.cs
@@ -1,0 +1,106 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using ReplayGenerator.Domain;
+using System.Net;
+using Xunit;
+
+namespace ReplayGenerator.Tests;
+
+public class ReplayFileBuilderFetchTests
+{
+	private sealed class StubHandler : HttpMessageHandler
+	{
+		private readonly Queue<HttpResponseMessage> _responses;
+		public int CallCount { get; private set; }
+
+		public StubHandler(IEnumerable<HttpResponseMessage> responses)
+		{
+			_responses = new Queue<HttpResponseMessage>(responses);
+		}
+
+		protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+		{
+			CallCount++;
+			if (_responses.Count == 0)
+				throw new InvalidOperationException("テスト用レスポンスが不足しています");
+			return Task.FromResult(_responses.Dequeue());
+		}
+	}
+
+	private static KyoshinImageRetryOptions FastOptions(int maxAttempts) => new()
+	{
+		MaxAttempts = maxAttempts,
+		InitialDelay = TimeSpan.Zero,
+		BackoffFactor = 1.0,
+		MaxDelay = TimeSpan.Zero,
+	};
+
+	private static byte[] DummyPng() => new byte[] { 0x89, 0x50, 0x4E, 0x47 };
+
+	[Fact(DisplayName = "FetchKyoshinImageAsync: 初回成功時はリトライしない")]
+	public async Task 初回成功時はリトライしない()
+	{
+		var handler = new StubHandler(new[]
+		{
+			new HttpResponseMessage(HttpStatusCode.OK) { Content = new ByteArrayContent(DummyPng()) },
+		});
+		var client = new HttpClient(handler);
+		var builder = new ReplayFileBuilder(client, NullLogger<ReplayFileBuilder>.Instance, null, FastOptions(3));
+
+		var result = await builder.FetchKyoshinImageAsync(new DateTime(2026, 5, 16, 12, 0, 0, DateTimeKind.Utc));
+
+		Assert.NotNull(result);
+		Assert.Equal(1, handler.CallCount);
+	}
+
+	[Fact(DisplayName = "FetchKyoshinImageAsync: 失敗後の再試行で成功する")]
+	public async Task 失敗後の再試行で成功する()
+	{
+		var handler = new StubHandler(new[]
+		{
+			new HttpResponseMessage(HttpStatusCode.NotFound),
+			new HttpResponseMessage(HttpStatusCode.NotFound),
+			new HttpResponseMessage(HttpStatusCode.OK) { Content = new ByteArrayContent(DummyPng()) },
+		});
+		var client = new HttpClient(handler);
+		var builder = new ReplayFileBuilder(client, NullLogger<ReplayFileBuilder>.Instance, null, FastOptions(5));
+
+		var result = await builder.FetchKyoshinImageAsync(new DateTime(2026, 5, 16, 12, 0, 0, DateTimeKind.Utc));
+
+		Assert.NotNull(result);
+		Assert.Equal(3, handler.CallCount);
+	}
+
+	[Fact(DisplayName = "FetchKyoshinImageAsync: リトライ上限到達時に null を返す")]
+	public async Task リトライ上限到達時にnullを返す()
+	{
+		var handler = new StubHandler(new[]
+		{
+			new HttpResponseMessage(HttpStatusCode.NotFound),
+			new HttpResponseMessage(HttpStatusCode.NotFound),
+			new HttpResponseMessage(HttpStatusCode.NotFound),
+		});
+		var client = new HttpClient(handler);
+		var builder = new ReplayFileBuilder(client, NullLogger<ReplayFileBuilder>.Instance, null, FastOptions(3));
+
+		var result = await builder.FetchKyoshinImageAsync(new DateTime(2026, 5, 16, 12, 0, 0, DateTimeKind.Utc));
+
+		Assert.Null(result);
+		Assert.Equal(3, handler.CallCount);
+	}
+
+	[Fact(DisplayName = "FetchKyoshinImageAsync: MaxAttempts=1 のときリトライしない")]
+	public async Task MaxAttempts1のときリトライしない()
+	{
+		var handler = new StubHandler(new[]
+		{
+			new HttpResponseMessage(HttpStatusCode.NotFound),
+		});
+		var client = new HttpClient(handler);
+		var builder = new ReplayFileBuilder(client, NullLogger<ReplayFileBuilder>.Instance, null, FastOptions(1));
+
+		var result = await builder.FetchKyoshinImageAsync(new DateTime(2026, 5, 16, 12, 0, 0, DateTimeKind.Utc));
+
+		Assert.Null(result);
+		Assert.Equal(1, handler.CallCount);
+	}
+}

--- a/tests/ReplayGenerator.Tests/ReplayGenerator.Tests.csproj
+++ b/tests/ReplayGenerator.Tests/ReplayGenerator.Tests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Sandboxes\ReplayGenerator\ReplayGenerator.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary

- 強震モニタ画像の公開遅延に起因するフレーム欠落を低減するため、`ReplayFileBuilder.FetchKyoshinImageAsync` に指数バックオフ付きのリトライを実装
- `KyoshinImageRetryOptions` で試行回数・初期間隔・バックオフ倍率・最大待機時間を設定化（環境変数 `KYOSHIN_IMAGE_RETRY_*` で上書き可能）
- 全試行失敗時は従来通り該当秒のフレームをスキップし WARNING ログを出力。挙動方針は `docs/replay-generator-kyoshin-image-retry.md` に明文化
- `tests/ReplayGenerator.Tests/` を新設し、リトライ挙動・遅延計算の単体テストを追加（7 ケース全合格）

Refs: YumNumm/eqmonitor-backend#391

## 設定

| 環境変数 | デフォルト | 用途 |
|---|---|---|
| `KYOSHIN_IMAGE_RETRY_MAX_ATTEMPTS` | 3 | 最大試行回数（初回含む） |
| `KYOSHIN_IMAGE_RETRY_INITIAL_DELAY_MS` | 500 | 初回リトライ前の待機時間 |
| `KYOSHIN_IMAGE_RETRY_BACKOFF_FACTOR` | 2.0 | 指数バックオフ倍率 |
| `KYOSHIN_IMAGE_RETRY_MAX_DELAY_MS` | 5000 | リトライ間の最大待機時間 |

## Test plan

- [x] `dotnet build src/Sandboxes/ReplayGenerator/ReplayGenerator.csproj` がエラーなく成功
- [x] `dotnet test tests/ReplayGenerator.Tests/ReplayGenerator.Tests.csproj` が 7/7 合格
- [ ] 実環境でリプレイ生成時の画像欠落が低減されること（運用確認）