### PR TITLE
fix(ReplayGenerator): アクティブセッションがない場合は snapshot fetch をスキップ

### DIFF
--- a/src/Sandboxes/ReplayGenerator/Domain/EewReplayWindow.cs
+++ b/src/Sandboxes/ReplayGenerator/Domain/EewReplayWindow.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace ReplayGenerator.Domain;
+
+/// <summary>
+/// EEWトリガーで生成するリプレイの時間窓。
+/// M5.0以上または深さ150km以上の場合は前後3分、それ以外は前後1分。
+/// </summary>
+public static class EewReplayWindow
+{
+	private const int NormalSeconds = 60;
+	private const int ExtendedSeconds = 180;
+
+	public static (int PreSeconds, int PostSeconds) ComputeMargins(double? magnitude, double? depthKm)
+	{
+		if (magnitude >= 5.0 || depthKm >= 150)
+			return (ExtendedSeconds, ExtendedSeconds);
+		return (NormalSeconds, NormalSeconds);
+	}
+}

--- a/src/Sandboxes/ReplayGenerator/Infrastructure/ValkeyStateManager.cs
+++ b/src/Sandboxes/ReplayGenerator/Infrastructure/ValkeyStateManager.cs
@@ -44,6 +44,11 @@ public class ValkeyStateManager
 			new("lastEventTime", state.LastEventTime.ToString("O")),
 			new("eewJson", state.EewJson ?? ""),
 			new("status", state.Status.ToString()),
+			new("associatedEewEventId", state.AssociatedEewEventId ?? ""),
+			new("associatedEewOriginTime", state.AssociatedEewOriginTime?.ToString("O") ?? ""),
+			new("associatedEewReportTime", state.AssociatedEewReportTime?.ToString("O") ?? ""),
+			new("associatedEewMagnitude", state.AssociatedEewMagnitude?.ToString() ?? ""),
+			new("associatedEewDepthKm", state.AssociatedEewDepthKm?.ToString() ?? ""),
 		};
 		await Db.HashSetAsync(key, entries);
 	}
@@ -62,6 +67,11 @@ public class ValkeyStateManager
 			LastEventTime = DateTime.TryParse(dict.GetValueOrDefault("lastEventTime"), out var let2) ? let2 : DateTime.UtcNow,
 			EewJson = dict.GetValueOrDefault("eewJson") is { Length: > 0 } eew ? eew : null,
 			Status = Enum.TryParse<SessionStatus>(dict.GetValueOrDefault("status"), out var s) ? s : SessionStatus.Tracking,
+			AssociatedEewEventId = dict.GetValueOrDefault("associatedEewEventId") is { Length: > 0 } id ? id : null,
+			AssociatedEewOriginTime = DateTime.TryParse(dict.GetValueOrDefault("associatedEewOriginTime"), out var eot) ? eot : null,
+			AssociatedEewReportTime = DateTime.TryParse(dict.GetValueOrDefault("associatedEewReportTime"), out var ert) ? ert : null,
+			AssociatedEewMagnitude = double.TryParse(dict.GetValueOrDefault("associatedEewMagnitude"), out var mag) ? mag : null,
+			AssociatedEewDepthKm = double.TryParse(dict.GetValueOrDefault("associatedEewDepthKm"), out var dep) ? dep : null,
 		};
 	}
 

--- a/src/Sandboxes/ReplayGenerator/Models/EewState.cs
+++ b/src/Sandboxes/ReplayGenerator/Models/EewState.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace ReplayGenerator.Models;
+
+public class EewState
+{
+	public string EventId { get; set; } = "";
+	public DateTime? OriginTime { get; set; }
+	public DateTime ReportTime { get; set; }
+	public double? Magnitude { get; set; }
+	public double? DepthKm { get; set; }
+}

--- a/src/Sandboxes/ReplayGenerator/Models/ShakeState.cs
+++ b/src/Sandboxes/ReplayGenerator/Models/ShakeState.cs
@@ -9,4 +9,10 @@ public class ShakeState
 	public DateTime LastEventTime { get; set; }
 	public string? EewJson { get; set; }
 	public SessionStatus Status { get; set; } = SessionStatus.Tracking;
+
+	public string? AssociatedEewEventId { get; set; }
+	public DateTime? AssociatedEewOriginTime { get; set; }
+	public DateTime? AssociatedEewReportTime { get; set; }
+	public double? AssociatedEewMagnitude { get; set; }
+	public double? AssociatedEewDepthKm { get; set; }
 }

--- a/src/Sandboxes/ReplayGenerator/Models/TriggerType.cs
+++ b/src/Sandboxes/ReplayGenerator/Models/TriggerType.cs
@@ -4,6 +4,7 @@ public enum TriggerType
 {
 	ShakeDetection,
 	Earthquake,
+	Eew,
 }
 
 public enum SessionStatus

--- a/src/Sandboxes/ReplayGenerator/Program.cs
+++ b/src/Sandboxes/ReplayGenerator/Program.cs
@@ -33,6 +33,7 @@ internal class Program
 		builder.Services.AddSingleton<ValkeyStateManager>();
 		builder.Services.AddSingleton<ShakeDetectionTracker>();
 		builder.Services.AddSingleton<EarthquakeTracker>();
+		builder.Services.AddSingleton<EewTracker>();
 		builder.Services.AddSingleton(sp =>
 		{
 			var logger = sp.GetRequiredService<ILogger<ReplayRepository>>();

--- a/src/Sandboxes/ReplayGenerator/Services/EewTracker.cs
+++ b/src/Sandboxes/ReplayGenerator/Services/EewTracker.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using ReplayGenerator.Infrastructure;
+using ReplayGenerator.Models;
+
+namespace ReplayGenerator.Services;
+
+public class EewTracker
+{
+	private readonly ValkeyStateManager _state;
+	private readonly ILogger<EewTracker> _logger;
+
+	public EewTracker(ValkeyStateManager state, ILogger<EewTracker> logger)
+	{
+		_state = state;
+		_logger = logger;
+	}
+
+	/// <summary>
+	/// EEW最終報を受信した際の処理。
+	/// 戻り値が非 null の場合はリプレイファイル生成を開始する。
+	/// </summary>
+	public async Task<EewState?> OnEewFinalReport(
+		string eventId, DateTime? originTime, DateTime reportTime,
+		double? magnitude, double? depthKm)
+	{
+		var acquired = await _state.TryAcquireLock("eew", eventId, TimeSpan.FromMinutes(10));
+		if (!acquired)
+		{
+			_logger.LogDebug($"EEWのロック取得失敗（重複）: {eventId}");
+			return null;
+		}
+
+		var state = new EewState
+		{
+			EventId = eventId,
+			OriginTime = originTime,
+			ReportTime = reportTime,
+			Magnitude = magnitude,
+			DepthKm = depthKm,
+		};
+
+		_logger.LogInformation($"EEWトリガー: {eventId} (M={magnitude}, depth={depthKm}km)");
+		return state;
+	}
+
+	public async Task CompleteAsync(string eventId)
+	{
+		await _state.ReleaseLock("eew", eventId);
+	}
+}

--- a/src/Sandboxes/ReplayGenerator/Services/ReplayGeneratorWorker.cs
+++ b/src/Sandboxes/ReplayGenerator/Services/ReplayGeneratorWorker.cs
@@ -76,10 +76,13 @@ public class ReplayGeneratorWorker : BackgroundService
 		{
 			try
 			{
-				var snapshot = await _stateManager.GetRealtimeSnapshot();
-				var (shouldGenerate, state) = await _shakeTracker.CheckTimerAsync(snapshot);
-				if (shouldGenerate && state != null)
-					await GenerateFromShake(state, snapshot);
+				if (_shakeTracker.HasActiveSession)
+				{
+					var snapshot = await _stateManager.GetRealtimeSnapshot();
+					var (shouldGenerate, state) = await _shakeTracker.CheckTimerAsync(snapshot);
+					if (shouldGenerate && state != null)
+						await GenerateFromShake(state, snapshot);
+				}
 			}
 			catch (Exception ex)
 			{

--- a/src/Sandboxes/ReplayGenerator/Services/ReplayGeneratorWorker.cs
+++ b/src/Sandboxes/ReplayGenerator/Services/ReplayGeneratorWorker.cs
@@ -21,6 +21,7 @@ public class ReplayGeneratorWorker : BackgroundService
 	private readonly ValkeyStateManager _stateManager;
 	private readonly ShakeDetectionTracker _shakeTracker;
 	private readonly EarthquakeTracker _earthquakeTracker;
+	private readonly EewTracker _eewTracker;
 	private readonly ReplayFileBuilder _replayBuilder;
 	private readonly ObjectStorageClient _storageClient;
 	private readonly ReplayRepository _repository;
@@ -33,6 +34,7 @@ public class ReplayGeneratorWorker : BackgroundService
 		ValkeyStateManager stateManager,
 		ShakeDetectionTracker shakeTracker,
 		EarthquakeTracker earthquakeTracker,
+		EewTracker eewTracker,
 		ReplayFileBuilder replayBuilder,
 		ObjectStorageClient storageClient,
 		ReplayRepository repository)
@@ -42,6 +44,7 @@ public class ReplayGeneratorWorker : BackgroundService
 		_stateManager = stateManager;
 		_shakeTracker = shakeTracker;
 		_earthquakeTracker = earthquakeTracker;
+		_eewTracker = eewTracker;
 		_replayBuilder = replayBuilder;
 		_storageClient = storageClient;
 		_repository = repository;
@@ -108,11 +111,14 @@ public class ReplayGeneratorWorker : BackgroundService
 				break;
 
 			case "EEW":
-				if (root.TryGetProperty("event", out var eewEvent))
+				if (root.TryGetProperty("item", out var eewItem))
 				{
 					var snapshot = await _stateManager.GetRealtimeSnapshot();
 					if (snapshot != null)
 						await _shakeTracker.SetEewSnapshot(snapshot);
+
+					if (eewItem.TryGetProperty("is_last_info", out var lastInfoProp) && lastInfoProp.GetBoolean())
+						await HandleEewFinalReport(eewItem);
 				}
 				break;
 
@@ -129,6 +135,50 @@ public class ReplayGeneratorWorker : BackgroundService
 		}
 	}
 
+	private async Task HandleEewFinalReport(JsonElement eewItem)
+	{
+		var eventId = eewItem.TryGetProperty("event_id", out var eidProp) ? eidProp.GetString() : null;
+		if (string.IsNullOrEmpty(eventId)) return;
+
+		DateTime? originTime = null;
+		if (eewItem.TryGetProperty("origin_time", out var otProp) && otProp.ValueKind == JsonValueKind.String)
+		{
+			var s = otProp.GetString();
+			if (!string.IsNullOrEmpty(s) && DateTime.TryParse(s, null, System.Globalization.DateTimeStyles.RoundtripKind, out var parsed))
+				originTime = parsed.Kind == DateTimeKind.Utc ? parsed : parsed.ToUniversalTime();
+		}
+
+		var reportTime = DateTime.UtcNow;
+		if (eewItem.TryGetProperty("report_time", out var rtProp) && rtProp.ValueKind == JsonValueKind.String)
+		{
+			var s = rtProp.GetString();
+			if (!string.IsNullOrEmpty(s) && DateTime.TryParse(s, null, System.Globalization.DateTimeStyles.RoundtripKind, out var parsed))
+				reportTime = parsed.Kind == DateTimeKind.Utc ? parsed : parsed.ToUniversalTime();
+		}
+
+		double? magnitude = eewItem.TryGetProperty("magnitude", out var magProp) && magProp.ValueKind == JsonValueKind.Number
+			? magProp.GetDouble() : null;
+
+		double? depthKm = null;
+		if (eewItem.TryGetProperty("hypocenter", out var hypo) && hypo.TryGetProperty("depth", out var depthProp))
+		{
+			if (depthProp.TryGetProperty("value", out var depthVal) && depthVal.ValueKind == JsonValueKind.Number)
+				depthKm = depthVal.GetDouble();
+		}
+
+		// 揺れ検知セッションが活性中ならマージ、そうでなければEEW単独生成
+		if (_shakeTracker.HasActiveSession)
+		{
+			await _shakeTracker.AssociateEew(eventId, originTime, reportTime, magnitude, depthKm);
+		}
+		else
+		{
+			var eewState = await _eewTracker.OnEewFinalReport(eventId, originTime, reportTime, magnitude, depthKm);
+			if (eewState != null)
+				await GenerateFromEew(eewState);
+		}
+	}
+
 	private async Task GenerateFromShake(ShakeState state, string? snapshotJson)
 	{
 		_logger.LogInformation($"揺れ検知リプレイファイル生成開始: {state.ShakeEventId}");
@@ -136,8 +186,23 @@ public class ReplayGeneratorWorker : BackgroundService
 		var sw = Stopwatch.StartNew();
 		try
 		{
-			var startTime = state.StartTime.AddSeconds(-10);
-			var endTime = state.LastEventTime.AddSeconds(5);
+			var shakeStart = state.StartTime.AddSeconds(-10);
+			var shakeEnd = state.LastEventTime.AddSeconds(5);
+
+			var startTime = shakeStart;
+			var endTime = shakeEnd;
+
+			// EEW関連付けがある場合は時間窓をマージ
+			if (state.AssociatedEewEventId != null && state.AssociatedEewReportTime.HasValue)
+			{
+				var (pre, post) = EewReplayWindow.ComputeMargins(state.AssociatedEewMagnitude, state.AssociatedEewDepthKm);
+				var eewAnchor = state.AssociatedEewOriginTime ?? state.AssociatedEewReportTime.Value;
+				var eewStart = eewAnchor.AddSeconds(-pre);
+				var eewEnd = state.AssociatedEewReportTime.Value.AddSeconds(post);
+				startTime = new DateTime(Math.Min(shakeStart.Ticks, eewStart.Ticks), DateTimeKind.Utc);
+				endTime = new DateTime(Math.Max(shakeEnd.Ticks, eewEnd.Ticks), DateTimeKind.Utc);
+				_logger.LogInformation($"EEW関連付けにより時間窓をマージ: {startTime:O} ～ {endTime:O}");
+			}
 
 			var (fileBytes, fileName) = await _replayBuilder.BuildAsync(startTime, endTime, snapshotJson);
 
@@ -147,6 +212,9 @@ public class ReplayGeneratorWorker : BackgroundService
 
 			var replayFileId = await _repository.InsertReplayFile(startTime, endTime, objectKey, (int)size);
 			await _repository.InsertTrigger(replayFileId, "shake_detection", state.ShakeEventId);
+
+			if (state.AssociatedEewEventId != null)
+				await _repository.InsertTrigger(replayFileId, "eew", state.AssociatedEewEventId);
 
 			_logger.LogInformation($"揺れ検知リプレイファイル生成完了: {fileName}");
 			ReplayMetrics.RecordGeneration("shake_detection", true, sw.Elapsed);
@@ -195,6 +263,42 @@ public class ReplayGeneratorWorker : BackgroundService
 		finally
 		{
 			await _earthquakeTracker.CompleteAsync(state.EventId);
+		}
+	}
+
+	private async Task GenerateFromEew(EewState state)
+	{
+		_logger.LogInformation($"EEWリプレイファイル生成開始: {state.EventId}");
+
+		var sw = Stopwatch.StartNew();
+		try
+		{
+			var (preSeconds, postSeconds) = EewReplayWindow.ComputeMargins(state.Magnitude, state.DepthKm);
+			var anchor = state.OriginTime ?? state.ReportTime;
+			var startTime = anchor.AddSeconds(-preSeconds);
+			var endTime = state.ReportTime.AddSeconds(postSeconds);
+
+			var snapshotJson = await _stateManager.GetRealtimeSnapshot();
+			var (fileBytes, fileName) = await _replayBuilder.BuildAsync(startTime, endTime, snapshotJson);
+
+			using var stream = new MemoryStream(fileBytes);
+			var objectKey = $"replay/{fileName}";
+			var size = await _storageClient.UploadAsync(objectKey, stream);
+
+			var replayFileId = await _repository.InsertReplayFile(startTime, endTime, objectKey, (int)size);
+			await _repository.InsertTrigger(replayFileId, "eew", state.EventId);
+
+			_logger.LogInformation($"EEWリプレイファイル生成完了: {fileName}");
+			ReplayMetrics.RecordGeneration("eew", true, sw.Elapsed);
+		}
+		catch (Exception ex)
+		{
+			_logger.LogWarning($"EEWリプレイファイル生成エラー: {ex.Message}");
+			ReplayMetrics.RecordGeneration("eew", false, sw.Elapsed);
+		}
+		finally
+		{
+			await _eewTracker.CompleteAsync(state.EventId);
 		}
 	}
 }

--- a/src/Sandboxes/ReplayGenerator/Services/ShakeDetectionTracker.cs
+++ b/src/Sandboxes/ReplayGenerator/Services/ShakeDetectionTracker.cs
@@ -65,6 +65,11 @@ public class ShakeDetectionTracker
 	}
 
 	/// <summary>
+	/// アクティブな揺れ検知セッションが存在するかどうか
+	/// </summary>
+	public bool HasActiveSession => _current != null;
+
+	/// <summary>
 	/// EEW 情報を関連付ける
 	/// </summary>
 	public async Task SetEewSnapshot(string eewJson)
@@ -72,6 +77,21 @@ public class ShakeDetectionTracker
 		if (_current == null) return;
 		_current.EewJson = eewJson;
 		await _state.SaveShakeState(_current);
+	}
+
+	/// <summary>
+	/// EEW最終報を揺れ検知セッションに関連付ける（マージ処理用）
+	/// </summary>
+	public async Task AssociateEew(string eewEventId, DateTime? originTime, DateTime reportTime, double? magnitude, double? depthKm)
+	{
+		if (_current == null) return;
+		_current.AssociatedEewEventId = eewEventId;
+		_current.AssociatedEewOriginTime = originTime;
+		_current.AssociatedEewReportTime = reportTime;
+		_current.AssociatedEewMagnitude = magnitude;
+		_current.AssociatedEewDepthKm = depthKm;
+		await _state.SaveShakeState(_current);
+		_logger.LogInformation($"EEW最終報を揺れ検知セッションに関連付けました: shake={_current.ShakeEventId}, eew={eewEventId}");
 	}
 
 	/// <summary>


### PR DESCRIPTION
## Summary

- `ReplayGeneratorWorker.cs` のタイマーループが `HasActiveSession = false`（平常時）でも毎秒 `GetRealtimeSnapshot()` を呼び出していた
- Valkey に保存された 5MB の `realtime:snapshot:v2` を 1 秒ごとに GET → 常時 ~5MB/s の通信が発生していた
- `HasActiveSession` ガードを追加し、揺れ検知セッションがアクティブな場合のみ snapshot を fetch するよう変更

## 動作確認

- `CheckTimerAsync` は `_current == null`（= `HasActiveSession = false`）のとき即座に `(false, null)` を返すため動作変化なし
- アクティブセッション中は従来通り snapshot を fetch してリプレイ生成に使用する

## 関連

- eqmonitor-backend Issue #394: https://github.com/YumNumm/eqmonitor-backend/issues/394

🤖 Generated with [Claude Code](https://claude.com/claude-code)